### PR TITLE
Add One String Guitar Theory app link

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
         <a href="https://kingscott00.github.io/chord-flow/">Chord Flow</a>
         <a href="https://kingscott00.github.io/all-the-chords/">All The Chords</a>
         <a href="https://kingscott00.github.io/guitar-looper/">Guitar Looper</a>
+        <a href="https://kingscott00.github.io/OneStringGuitarTheory/">One String Guitar Theory</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Adds a link to the One String Guitar Theory app under the Music Playing Apps section, pointing to https://kingscott00.github.io/OneStringGuitarTheory/

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016kd4eF6q4o3nDs4SxF8yFp)_