### PR TITLE
Add Midi Bloom Studio app link

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
         <a href="https://kingscott00.github.io/OneStringGuitarTheory/">One String Guitar Theory</a>
         <a href="https://kingscott00.github.io/OneStringGuitarTheoryLabCodex/">One String Theory Lab Codex</a>
         <a href="https://kingscott00.github.io/ChordVisualizer/">Chord Visualizer</a>
+        <a href="https://kingscott00.github.io/MusicBloomStudio/">Midi Bloom Studio</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Adds a link to Midi Bloom Studio under the Music Playing Apps section, pointing to https://kingscott00.github.io/MusicBloomStudio/

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016kd4eF6q4o3nDs4SxF8yFp)_