### PR TITLE
Reorganize app sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,56 +103,52 @@
     </header>
 
     <section>
-      <h2>Work Apps</h2>
-      <div class="app-links">
-        <a href="https://kingscott00.github.io/TaxBillCalculator.html">Tax Bill Calculator</a>
-      </div>
-    </section>
-
-    <section>
       <h2>Music Playing Apps</h2>
       <div class="app-links">
         <a href="https://kingscott00.github.io/guitar-neck/">Guitar Neck</a>
-        <a href="https://kingscott00.github.io/GuitarChordsAndApreggios/">Guitar Chords and Arpeggios</a>
-        <a href="https://kingscott00.github.io/chord-flow/">Chord Flow</a>
-        <a href="https://kingscott00.github.io/all-the-chords/">All The Chords</a>
-        <a href="https://kingscott00.github.io/guitar-looper/">Guitar Looper</a>
-        <a href="https://kingscott00.github.io/OneStringGuitarTheory/">One String Guitar Theory</a>
-        <a href="https://kingscott00.github.io/OneStringGuitarTheoryLabCodex/">One String Theory Lab Codex</a>
         <a href="https://kingscott00.github.io/ChordVisualizer/">Chord Visualizer</a>
         <a href="https://kingscott00.github.io/MusicBloomStudio/">Midi Bloom Studio</a>
+        <a href="https://kingscott00.github.io/chord-flow/">Chord Flow</a>
+        <a href="https://kingscott00.github.io/all-the-chords/">All The Chords</a>
       </div>
     </section>
 
     <section>
-      <h2>Energy/Spirituality</h2>
+      <h2>Music Learning Apps</h2>
       <div class="app-links">
-        <a href="#" class="disabled">Spirit Guide Tracker</a>
+        <a href="https://kingscott00.github.io/OneStringGuitarTheory/">One String Guitar Theory</a>
+        <a href="https://kingscott00.github.io/OneStringGuitarTheoryLabCodex/">One String Theory Lab Codex</a>
+        <a href="https://kingscott00.github.io/GuitarChordsAndApreggios/">Guitar Chords and Arpeggios</a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Health</h2>
+      <div class="app-links">
+        <a href="https://kingscott00.github.io/low-oxalate-recipes.html">Low Oxalate Recipes</a>
+        <a href="https://kingscott00.github.io/food-guide.html">Inflamation Diet Food Guide</a>
+        <a href="https://kingscott00.github.io/ebv-plan.html">EBV Plan</a>
       </div>
     </section>
 
     <section>
       <h2>Tools</h2>
       <div class="app-links">
-        <a href="https://kingscott00.github.io/food-guide.html">Inflamation Diet Food Guide</a>
-        <a href="https://kingscott00.github.io/ebv-plan.html">EBV Plan</a>
-        <a href="https://kingscott00.github.io/low-oxalate-recipes.html">Low Oxalate Recipes</a>
-      </div>
-    </section>
-
-    <section>
-      <h2>Other Apps</h2>
-      <div class="app-links">
-        <a href="https://kingscott00.github.io/RecordViewer/recordViewer.html">Record Viewer</a>
-        <a href="https://kingscott00.github.io/RecordViewerRetro/recordViewer.html">Record Viewer Retro</a>
         <a href="https://kingscott00.github.io/RecordLibrary/">Record Library</a>
       </div>
     </section>
 
     <section>
-      <h2>Fun &amp; Games</h2>
+      <h2>Fun</h2>
       <div class="app-links">
         <a href="https://kingscott00.github.io/santaslist/index.html">Santa's List</a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Work Apps</h2>
+      <div class="app-links">
+        <a href="https://kingscott00.github.io/TaxBillCalculator.html">Tax Bill Calculator</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Reorganize into Music Playing Apps, Music Learning Apps, Health, Tools, Fun, Work Apps (in that order)
- Remove Guitar Looper, Record Viewer, Record Viewer Retro
- Remove the Energy/Spirituality section (Spirit Guide Tracker removed, leaving it empty)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016kd4eF6q4o3nDs4SxF8yFp)_