### PR TITLE
Add One String Theory Lab Grok app link

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
       <div class="app-links">
         <a href="https://kingscott00.github.io/OneStringGuitarTheory/">One String Guitar Theory</a>
         <a href="https://kingscott00.github.io/OneStringGuitarTheoryLabCodex/">One String Theory Lab Codex</a>
+        <a href="https://kingscott00.github.io/OneStringGuitarTheoryLabGrok/">One String Theory Lab Grok</a>
         <a href="https://kingscott00.github.io/GuitarChordsAndApreggios/">Guitar Chords and Arpeggios</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Adds a link to One String Theory Lab Grok under the Music Learning Apps section, just below One String Theory Lab Codex, pointing to https://kingscott00.github.io/OneStringGuitarTheoryLabGrok/

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016kd4eF6q4o3nDs4SxF8yFp)_